### PR TITLE
PHP_EOL only added after <![CDATA[

### DIFF
--- a/EFeedItemRSS2.php
+++ b/EFeedItemRSS2.php
@@ -73,13 +73,12 @@ class EFeedItemRSS2 extends EFeedItemAbstract{
 		if(in_array($tag->name,$this->CDATAEncoded))
 		{
 			$element .= CHtml::openTag($tag->name,$tag->attributes);
-			$element .= '<![CDATA[';
+			$element .= '<![CDATA['.PHP_EOL;
 			
 		}else 
 		{
 			$element .= CHtml::openTag($tag->name,$tag->attributes);
 		}
-		$element .= PHP_EOL;
 		
 		if(is_array($tag->content))
 		{ 


### PR DESCRIPTION
In the old situation tags could look like this:
<tag>
content</tag>

instead of
<tag>content</tag>

The old behavior can cause problems in tools like mailchimp when you print the link or guid into an href. PHP_EOL is then translated to a space, making the link invalid.
