### PR TITLE
Fix for Feeds when $tag->content is an array

### DIFF
--- a/EFeedItemAtom.php
+++ b/EFeedItemAtom.php
@@ -100,9 +100,9 @@ class EFeedItemAtom extends EFeedItemAbstract {
 			
 		if(is_array($tag->content))
 		{ 
-			foreach ($tag->content as $tag => $content) 
+			foreach ($tag->content as $tagName => $content) 
 			{
-				$tmpTag = new EFeedTag($tag, $content);
+				$tmpTag = new EFeedTag($tagName, $content);
 				
 				$element .= $this->getElement( $tmpTag );
 			}

--- a/EFeedItemRSS1.php
+++ b/EFeedItemRSS1.php
@@ -87,9 +87,9 @@ class EFeedItemRSS1 extends EFeedItemAbstract{
 		
 		if(is_array($tag->content))
 		{ 
-			foreach ($tag->content as $tag => $content) 
+			foreach ($tag->content as $tagName => $content) 
 			{
-				$tmpTag = new EFeedTag($tag, $content);
+				$tmpTag = new EFeedTag($tagName, $content);
 				
 				$element .= $this->getElement( $tmpTag );
 			}

--- a/EFeedItemRSS2.php
+++ b/EFeedItemRSS2.php
@@ -83,9 +83,9 @@ class EFeedItemRSS2 extends EFeedItemAbstract{
 		
 		if(is_array($tag->content))
 		{ 
-			foreach ($tag->content as $tag => $content) 
+			foreach ($tag->content as $tagName => $content) 
 			{
-				$tmpTag = new EFeedTag($tag, $content);
+				$tmpTag = new EFeedTag($tagName, $content);
 				
 				$element .= $this->getElement( $tmpTag );
 			}


### PR DESCRIPTION
If $tag->content is an array the foreach destroys the closing tag.

Fixed the Issue in Atom, RSS1 and RSS2